### PR TITLE
Merge overrides

### DIFF
--- a/src/fcos/configs/files/prep-machine.sh
+++ b/src/fcos/configs/files/prep-machine.sh
@@ -12,9 +12,6 @@ done
 containerd config default > /etc/containerd/config.toml
 sed -i 's/imports = .*/imports = ["\/etc\/containerd\/config.d\/*.toml"]/' /etc/containerd/config.toml
 
-# This only work in the main config. It does not work as an import
-sed -i 's/SystemdCgroup = .*/SystemdCgroup = true/g' /etc/containerd/config.toml
-
 ln -s /usr/lib/systemd/system/kubelet.service /etc/systemd/system/multi-user.target.wants/kubelet.service
 
 systemctl disable docker.socket

--- a/src/fcos/configs/kubernetes.ign.php
+++ b/src/fcos/configs/kubernetes.ign.php
@@ -91,53 +91,61 @@ foreach($directories as $directory) {
     $ignition->storage->directories[] = $dir;
 }
 
+// Each section of plugins will be completely overwritten when there is an import
+// All configs should be in a single import
+// https://github.com/containerd/containerd/issues/7982#issuecomment-1447981526
+
 // Configure caching servers
-$file = (object)[];
-$file->path = "/etc/containerd/config.d/cache.toml";
-$file->contents = (object)[];
-$file->contents->compression = "";
-$content = "version = 2
-
-[plugins.\"io.containerd.grpc.v1.cri\".registry]
-  config_path = \"/etc/containerd/certs.d\"
-";
-$file->contents->source = "data:," . rawurlencode($content);
-$ignition->storage->files[] = $file;
-
 foreach($caching_servers as $cache_srv) {
-    $dir = (object)[];
-    $dir->path = "/etc/containerd/certs.d/" . $cache_srv['name'];
-    $ignition->storage->directories[] = $dir;
+  $dir = (object)[];
+  $dir->path = "/etc/containerd/certs.d/" . $cache_srv['name'];
+  $ignition->storage->directories[] = $dir;
 
-    $file = (object)[];
-    $file->path = "/etc/containerd/certs.d/" . $cache_srv['name'] . "/hosts.toml";
-    $file->contents = (object)[];
-    $file->contents->compression = "";
-    $content = "server = \"" . $cache_srv['server'] . "\"
+  $file = (object)[];
+  $file->path = "/etc/containerd/certs.d/" . $cache_srv['name'] . "/hosts.toml";
+  $file->contents = (object)[];
+  $file->contents->compression = "";
+  $content = "server = \"" . $cache_srv['server'] . "\"
 
 [host.\"" . $cache_srv['cache'] . "\"]
-  capabilities = [\"pull\", \"resolve\"]
-  override_path = true
+capabilities = [\"pull\", \"resolve\"]
+override_path = true
 ";
-    $file->contents->source = "data:," . rawurlencode($content);
-    $ignition->storage->files[] = $file;
+  $file->contents->source = "data:," . rawurlencode($content);
+  $ignition->storage->files[] = $file;
 }
+
+$overrides = "version = 2
+
+[plugins]
+  [plugins.\"io.containerd.grpc.v1.cri\"]
+    [plugins."io.containerd.grpc.v1.cri".containerd]
+      [plugins."io.containerd.grpc.v1.cri".containerd.runtimes]
+        [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc]
+          [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc.options]
+            SystemdCgroup = true
+    [plugins.\"io.containerd.grpc.v1.cri\".registry]
+      config_path = \"/etc/containerd/certs.d\"
+";
 
 // Configure registry authentication
 foreach($registry_auth as $auth) {
-    $file = (object)[];
-    $file->path = "/etc/containerd/config.d/auth_" . $auth['registry'] . ".toml";
-    $file->contents = (object)[];
-    $file->contents->compression = "";
-    $content = "version = 2
-
-[plugins.\"io.containerd.grpc.v1.cri\".registry.configs.\"" . $auth['registry'] . "\".auth]
-  username = \"" . $auth['username'] . "\"                          
-  password = \"" . $auth['password'] . "\"
+    $overrides .= "
+      [plugins.\"io.containerd.grpc.v1.cri\".registry.configs]
+        [plugins.\"io.containerd.grpc.v1.cri\".registry.configs.\"" . $auth['registry'] . "\"]
+          [plugins.\"io.containerd.grpc.v1.cri\".registry.configs.\"" . $auth['registry'] . "\".auth]
+            username = \"" . $auth['username'] . "\"
+            password = \"" . $auth['password'] . "\"
 ";
-    $file->contents->source = "data:," . rawurlencode($content);
-    $ignition->storage->files[] = $file;
 }
+
+// Add overrides to file list
+$file = (object)[];
+$file->path = "/etc/containerd/config.d/overrides.toml";
+$file->contents = (object)[];
+$file->contents->compression = "";
+$file->contents->source = "data:," . rawurlencode($overrides);
+$ignition->storage->files[] = $file;
 
 // Create kubeadm config for init and join
 $file = (object)[];

--- a/src/fcos/configs/kubernetes.ign.php
+++ b/src/fcos/configs/kubernetes.ign.php
@@ -119,10 +119,10 @@ $overrides = "version = 2
 
 [plugins]
   [plugins.\"io.containerd.grpc.v1.cri\"]
-    [plugins."io.containerd.grpc.v1.cri".containerd]
-      [plugins."io.containerd.grpc.v1.cri".containerd.runtimes]
-        [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc]
-          [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc.options]
+    [plugins.\"io.containerd.grpc.v1.cri\".containerd]
+      [plugins.\"io.containerd.grpc.v1.cri\".containerd.runtimes]
+        [plugins.\"io.containerd.grpc.v1.cri\".containerd.runtimes.runc]
+          [plugins.\"io.containerd.grpc.v1.cri\".containerd.runtimes.runc.options]
             SystemdCgroup = true
     [plugins.\"io.containerd.grpc.v1.cri\".registry]
       config_path = \"/etc/containerd/certs.d\"

--- a/src/fcos/configs/kubernetes.ign.php
+++ b/src/fcos/configs/kubernetes.ign.php
@@ -122,6 +122,7 @@ $overrides = "version = 2
     [plugins.\"io.containerd.grpc.v1.cri\".containerd]
       [plugins.\"io.containerd.grpc.v1.cri\".containerd.runtimes]
         [plugins.\"io.containerd.grpc.v1.cri\".containerd.runtimes.runc]
+          runtime_type = "io.containerd.runc.v2"
           [plugins.\"io.containerd.grpc.v1.cri\".containerd.runtimes.runc.options]
             SystemdCgroup = true
     [plugins.\"io.containerd.grpc.v1.cri\".registry]


### PR DESCRIPTION
While containerd will start containers. It will have issues tracking them because SystemdCgroup gets reset to false. This PR will merge the overrides in to a single toml and include `SystemdCgroup = true` so it can continue to be set.